### PR TITLE
Set `coll-schema` if Schema is JSON

### DIFF
--- a/src/Contract Test Generator.postman_collection.json
+++ b/src/Contract Test Generator.postman_collection.json
@@ -297,6 +297,7 @@
 									"        pm.test('Schema is JSON', function(){\r",
 									"            pm.expect(1).to.equal(1);\r",
 									"        });\r",
+									"        pm.collectionVariables.set('coll-schema', jsonData.schema.schema);\r",
 									"    }\r",
 									"    else {\r",
 									"        pm.test('Schema translates to JSON', function(){\r",


### PR DESCRIPTION
This sets the collection environment variable `coll-schema` during the `Get API Schema` request if schema type is JSON, which can then be used in later requests.

Resolves #2 