### PR TITLE
schemaParam out of scope fix

### DIFF
--- a/src/Contract Test Generator.postman_collection.json
+++ b/src/Contract Test Generator.postman_collection.json
@@ -1035,7 +1035,7 @@
 									"            const paramValue = loadParameterValue(param);\r",
 									"            if (paramType == 'header') {\r",
 									"                pm.request.headers.upsert({ key: param.name, value: paramValue });\r",
-									"            } else if (paramType == 'query' && schemaParam.required == true) {\r",
+									"            } else if (paramType == 'query' && param.required == true) {\r",
 									"                pm.request.url.query.upsert({ key: param.name, value: paramValue });\r",
 									"            }\r",
 									"        }\r",


### PR DESCRIPTION
`schemaParam` is defined in a separate block resulting in an 'undefined' error when evaluating if query parameters are required or not. The change to `param.required` is already defined and returns the desired value.

Fixes issue #3 