### PR TITLE
Update Contract Test Generator.postman_collection.json

### DIFF
--- a/src/Contract Test Generator.postman_collection.json
+++ b/src/Contract Test Generator.postman_collection.json
@@ -439,7 +439,7 @@
 									"pm.test('Schema has server/baseUrl defined', function () {\r",
 									"    const servers = schema.servers;\r",
 									"    pm.expect(servers).to.not.be.undefined;\r",
-									"    const serverToTest = servers.find(s => s.url.toLowerCase() == server.toLowerCase());\r",
+									"    const serverToTest = servers.find(s => s.description.toLowerCase() == server.toLowerCase());\r",
 									"    pm.expect(serverToTest).to.not.be.undefined;\r",
 									"\r",
 									"    pm.expect(serverToTest).to.have.property('url');\r",


### PR DESCRIPTION
The server to test was being selected based on it's url rather than it's description (description is what the docs tell you to put in the env-server variable).